### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Unreleased
 ==================
 
 
-0.7.3 (2024-04-09)
+1.0.0 (2024-04-10)
 ==================
 * Add compatibility with Django 4.2
 * Dropped support for Django < 3.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,17 @@ Changelog
 
 Unreleased
 ==================
+
+
+0.7.3 (2024-04-09)
+==================
 * Add compatibility with Django 4.2
 * Dropped support for Django < 3.1
 * Dropped support for python < 3.8
+* Added support for Django 4.2
+* Added support for python 3.11
+* moved to `FidelityInternational/django-multisite-plus` as the new repository
+* renamed to `django-multisite-plus-fil`
 
 
 0.7.2 (unreleased)

--- a/addon.json
+++ b/addon.json
@@ -1,5 +1,5 @@
 {
-    "package-name": "django-multisite-plus",
+    "package-name": "django-multisite-plus-fil",
     "installed-apps": [
         "multisite"
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42.0.0",
+    "setuptools",
     "setuptools_scm[toml]>=6.2",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=42.0.0",
     "setuptools_scm[toml]>=6.2",
     "wheel",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ python_requires = >=3.8
 setup_requires = setuptools_scm[toml]
 install_requires =
     django>=3.2,<5
-    django-multisite-fil @ https://github.com/FidelityInternational/django-multisite/tarball/release/1.10.0#egg=django-multisite-fil
-    djangocms-multisite-fil @ https://github.com/FidelityInternational/djangocms-multisite/tarball/release/1.0.0#egg=djangocms-multisite-fil
+    django-multisite-fil @ https://github.com/FidelityInternational/django-multisite/tarball/release/1.10.0
+    djangocms-multisite-fil @ https://github.com/FidelityInternational/djangocms-multisite/tarball/release/1.0.0
     aldryn-django
     aldryn_addons
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ python_requires = >=3.8
 setup_requires = setuptools_scm[toml]
 install_requires =
     django>=3.2,<5
-    django-multisite @ https://github.com/FidelityInternational/django-multisite/tarball/release/1.10.0#egg=django-multisite
-    djangocms-multisite @ https://github.com/FidelityInternational/djangocms-multisite/tarball/release/1.0.0#egg=djangocms-multisite
+    django-multisite-fil @ https://github.com/FidelityInternational/django-multisite/tarball/release/1.10.0#egg=django-multisite-fil
+    djangocms-multisite-fil @ https://github.com/FidelityInternational/djangocms-multisite/tarball/release/1.0.0#egg=djangocms-multisite-fil
     aldryn-django
     aldryn_addons
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ python_requires = >=3.8
 setup_requires = setuptools_scm[toml]
 install_requires =
     django>=3.2,<5
-    django-multisite @ https://github.com/FidelityInternational/django-multisite/tarball/master#egg=django-multisite
-    djangocms-multisite @ https://github.com/FidelityInternational/djangocms-multisite/tarball/master#egg=djangocms-multisite
+    django-multisite @ https://github.com/FidelityInternational/django-multisite/tarball/release/1.10.0#egg=django-multisite
+    djangocms-multisite @ https://github.com/FidelityInternational/djangocms-multisite/tarball/release/1.0.0#egg=djangocms-multisite
     aldryn-django
     aldryn_addons
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = django-multisite-plus
+name = django-multisite-plus-fil
 author = Divio AG
 author_email = info@divio.com
 license = BSD 3-Clause License
@@ -36,8 +36,8 @@ python_requires = >=3.8
 setup_requires = setuptools_scm[toml]
 install_requires =
     django>=3.2,<5
-    django-multisite @ https://github.com/FidelityInternational/django-multisite/tarball/feat/django-42-compat#egg=django-multisite
-    djangocms-multisite @ https://github.com/FidelityInternational/djangocms-multisite/tarball/feat/django-42-compat#egg=djangocms-multisite
+    django-multisite @ https://github.com/FidelityInternational/django-multisite/tarball/master#egg=django-multisite
+    djangocms-multisite @ https://github.com/FidelityInternational/djangocms-multisite/tarball/master#egg=djangocms-multisite
     aldryn-django
     aldryn_addons
     click

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import find_packages, setup
 
 
 setup(
-    name="django-multisite-plus",
-    version="0.7.2",
+    name="django-multisite-plus-fil",
+    version="0.7.3",
     author="Divio AG",
     author_email="info@divio.com",
     url="https://github.com/divio/django-multisite-plus",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="django-multisite-plus-fil",
-    version="0.7.3",
+    version="1.0.0",
     author="Divio AG",
     author_email="info@divio.com",
     url="https://github.com/divio/django-multisite-plus",


### PR DESCRIPTION
* renamed to `django-multisite-plus-fil`
* 
we fork the addon and create a new one, so we should use version 1.0.0 as the initial version for it.
re-use the existing branch name